### PR TITLE
Require warden-validator-symfony ^1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Unreleased
 
+### v1.4.1 (2022-10-24)
+
+* Require warden-validator-symfony ^1.2.1 to be compatible 
+  with warden/core ^1.2.1 to avoid using depreciated checkMX option
+
 ### v1.4.0 (2022-10-17)
 
 * Support PHP 8.1

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "kohana/koharness": "dev-master",
     "johnkary/phpunit-speedtrap": "^3.3",
     "phpunit/phpunit": "^9.5.5",
-    "egulias/email-validator": "^2.1.16"
+    "egulias/email-validator": "^3.2"
   },
   "repositories": [
     {


### PR DESCRIPTION
To be compatible with warden core 1.2.1