### PR TITLE
Remove direct deps on symfony/validator and egulias/email-validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Unreleased
 
+### v1.3.1 (2022-10-24)
+
+* Remove direct dependency on symfony/validator and (dev) egulias/email-validator -
+  these are already required in by dependencies e.g. ingenerator/warden-validator-symfony
+  and so we don't actually need to directly require them. These dependencies were
+  causing conflicts when ingenerator/warden-validator-symfony wanted to pull in a new
+  symfony/validator release as a non-breaking change.
+
 ### v1.3.0 (2021-04-21)
 
 * Support php8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### v1.3.1 (2022-10-24)
 
+* Bump minimum supported swiftmailer to 6.3.0 and mark a conflict with egulias/email-validator
+  before 3.0 (swiftmailer claims to support the 2.x series but in fact this is broken).
+
 * Remove direct dependency on symfony/validator and (dev) egulias/email-validator -
   these are already required in by dependencies e.g. ingenerator/warden-validator-symfony
   and so we don't actually need to directly require them. These dependencies were

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
   "require": {
     "php": "^7.4 || ~8.0.0",
     "ext-json": "*",
-    "symfony/validator": "^3.0",
     "ingenerator/warden-core": "^1.1",
     "ingenerator/warden-validator-symfony": "^1.1",
     "ingenerator/warden-persistence-doctrine": "^1.1",
@@ -33,8 +32,7 @@
   "require-dev": {
     "kohana/koharness": "dev-master",
     "johnkary/phpunit-speedtrap": "^3.0",
-    "phpunit/phpunit": "^9.0",
-    "egulias/email-validator": "^2.1.16"
+    "phpunit/phpunit": "^9.0"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,10 @@
     }
   },
   "config": {
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "allow-plugins": {
+      "composer/installers": true
+    }
   },
   "extra": {
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,16 @@
     "ingenerator/kohana-extras": "^2.0",
     "ingenerator/kohana-core": "^4.7",
     "ingenerator/tokenista": "^1.4",
-    "swiftmailer/swiftmailer": "^6.2.3",
+    "swiftmailer/swiftmailer": "^6.3",
     "composer/installers": "^1.9"
   },
   "require-dev": {
     "kohana/koharness": "dev-master",
     "johnkary/phpunit-speedtrap": "^3.0",
     "phpunit/phpunit": "^9.0"
+  },
+  "conflict": {
+    "egulias/email-validator": "<3"
   },
   "repositories": [
     {


### PR DESCRIPTION
These should just be referenced by the packages that we depend on that bring them in.