### PR TITLE
change: Drop dependency on doctrine/annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Drop composer dependency on doctrine/annotations - not used by warden since warden-core:2.0
+
 ### v3.0.0 (2024-09-25)
 
 * Support PHP 8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### v3.1.0 (2024-12-16)
+
 * Drop composer dependency on doctrine/annotations - not used by warden since warden-core:2.0
 
 ### v3.0.0 (2024-09-25)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "php": "~8.2.0 || ~8.3.0",
     "ext-json": "*",
     "composer/installers": "^1.9",
-    "doctrine/annotations": "^1.13",
     "ingenerator/kohana-core": "^4.7",
     "ingenerator/kohana-extras": "^3.1",
     "ingenerator/kohana-view": "^4.4",

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -9,11 +9,8 @@ require_once __DIR__.'/../koharness_bootstrap.php';
 // Require in warden core test bootstrap to autoload mocks and base tests
 require_once __DIR__.'/../vendor/ingenerator/warden-core/test/bootstrap.php';
 
-// Require dummy page layout view
-require_once __DIR__.'/../vendor/ingenerator/kohana-view/tests/mock/ViewModel/PageLayout/DummyPageLayoutView.php';
-
 // Autoload mocks and test-support helpers that should not autoload in the main app
 $mock_loader = new \Composer\Autoload\ClassLoader;
-$mock_loader->addPsr4('test\\mock\\Ingenerator\\Warden\\UI\\Kohana\\', [__DIR__.'/mock/']);
+$mock_loader->addPsr4('test\\mock\\', [__DIR__.'/mock/']);
 $mock_loader->addPsr4('test\\unit\\Ingenerator\\Warden\\UI\\Kohana\\', [__DIR__.'/unit/']);
 $mock_loader->register();

--- a/test/mock/View/DummyPageLayoutView.php
+++ b/test/mock/View/DummyPageLayoutView.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace test\mock\View;
+
+use Ingenerator\KohanaView\ViewModel\PageLayout\AbstractPageLayoutView;
+
+class DummyPageLayoutView extends AbstractPageLayoutView
+{
+
+}

--- a/test/unit/View/ChangeEmailViewTest.php
+++ b/test/unit/View/ChangeEmailViewTest.php
@@ -10,9 +10,8 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\Warden\Core\Entity\SimpleUser;
 use Ingenerator\Warden\UI\Kohana\View\ChangeEmailView;
-use Ingenerator\Warden\UI\Kohana\View\EmailVerificationView;
 use InvalidArgumentException;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class ChangeEmailViewTest extends AbstractFormViewTest
 {

--- a/test/unit/View/ChangePasswordViewTest.php
+++ b/test/unit/View/ChangePasswordViewTest.php
@@ -9,11 +9,9 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\Warden\Core\Entity\SimpleUser;
-use Ingenerator\Warden\UI\Kohana\View\ChangeEmailView;
 use Ingenerator\Warden\UI\Kohana\View\ChangePasswordView;
-use Ingenerator\Warden\UI\Kohana\View\EmailVerificationView;
 use InvalidArgumentException;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class ChangePasswordViewTest extends AbstractFormViewTest
 {

--- a/test/unit/View/EmailVerificationViewTest.php
+++ b/test/unit/View/EmailVerificationViewTest.php
@@ -9,7 +9,7 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\Warden\UI\Kohana\View\EmailVerificationView;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class EmailVerificationViewTest extends AbstractFormViewTest
 {

--- a/test/unit/View/LoginViewTest.php
+++ b/test/unit/View/LoginViewTest.php
@@ -8,9 +8,9 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 
 
 use Ingenerator\KohanaView\ViewModel\PageContentView;
-use Ingenerator\Warden\UI\Kohana\View\LoginView;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
 use Ingenerator\Warden\Core\Support\FixedUrlProviderStub;
+use Ingenerator\Warden\UI\Kohana\View\LoginView;
+use test\mock\View\DummyPageLayoutView;
 
 class LoginViewTest extends AbstractFormViewTest
 {

--- a/test/unit/View/PasswordResetViewTest.php
+++ b/test/unit/View/PasswordResetViewTest.php
@@ -9,7 +9,7 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\Warden\UI\Kohana\View\PasswordResetView;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class PasswordResetViewTest extends AbstractFormViewTest
 {

--- a/test/unit/View/ProfileViewTest.php
+++ b/test/unit/View/ProfileViewTest.php
@@ -8,10 +8,10 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 
 
 use Ingenerator\KohanaView\ViewModel\PageContentView;
-use Ingenerator\Warden\UI\Kohana\View\ProfileView;
 use Ingenerator\Warden\Core\Entity\SimpleUser;
+use Ingenerator\Warden\UI\Kohana\View\ProfileView;
 use InvalidArgumentException;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class ProfileViewTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/unit/View/RegistrationViewTest.php
+++ b/test/unit/View/RegistrationViewTest.php
@@ -10,7 +10,7 @@ namespace test\unit\Ingenerator\Warden\UI\Kohana\View;
 use Ingenerator\KohanaView\ViewModel\PageContentView;
 use Ingenerator\Warden\UI\Kohana\Form\Fieldset;
 use Ingenerator\Warden\UI\Kohana\View\RegistrationView;
-use test\mock\ViewModel\PageLayout\DummyPageLayoutView;
+use test\mock\View\DummyPageLayoutView;
 
 class RegistrationViewTest extends AbstractFormViewTest
 {


### PR DESCRIPTION
This is a hangover from warden-core:1.x where we were using warden-validator-symfony as a separate package. Since #26 and warden-core:2.x the validation is built into warden-core and uses attributes so the doctrine/annotations dependency is redundant.

This may cause issues if projects have an undeclared direct dependency on doctrine/annotations and are not requiring anything else that requires it.