### PR TITLE
fix: Fix composer version requirement for ingenerator/kohana-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+### v4.0.0-alpha2 (2025-11-04)
+
+* Fix version specification for ingenerator/kohana-view ^5.0@alpha
+
 ### v4.0.0-alpha (2025-11-03)
 
 * Drop support for PHP < 8.4

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "composer/installers": "^1.9 || ^2.0",
     "ingenerator/kohana-core": "^4.7",
     "ingenerator/kohana-extras": "^3.1",
-    "ingenerator/kohana-view": "5.x-dev@dev",
+    "ingenerator/kohana-view": "^5.0@alpha",
     "ingenerator/tokenista": "^1.4",
     "ingenerator/warden-core": "^2.1.1",
     "ingenerator/warden-persistence-doctrine": "^2.0",


### PR DESCRIPTION
Should have bumped over to ^5.0@alpha for our 4.0-alpha release but I had accidentally left it pointing at the dev branch.